### PR TITLE
(app.py): add interpreter python3 in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import os
 import json


### PR DESCRIPTION
When executing the app.py, it gave error if you did not specify to open it with python. I added a line to specify to run with pyhon3.